### PR TITLE
Fix #1 issue: mecab import, config.py tab error

### DIFF
--- a/Anki 2.1/shinmeikai_definitions/config.py
+++ b/Anki 2.1/shinmeikai_definitions/config.py
@@ -3,7 +3,7 @@
 class Config(object):
     enableKanjiKeywords = True
     addFuriganaToDef = True
-	orderDefByFreq = True
+    orderDefByFreq = True
     maxNumberOfDefs = 3
     defSrcField = ["Focus"]
     defDstField = ["Meaning"]

--- a/Anki 2.1/shinmeikai_definitions/main.py
+++ b/Anki 2.1/shinmeikai_definitions/main.py
@@ -3,15 +3,22 @@
 from aqt import mw
 from aqt.utils import showInfo
 from aqt.qt import *
+import importlib
 
 from anki.hooks import addHook
-from japanese.reading import mecab
 
 from shinmeikai_definitions import config, shinmeikai, jpParser
 
 conf = config.Config()
 
+# Importing mecab from Japanese Support or MIA Japanese Support
+try:
+    reading = importlib.import_module('3918629684.reading')
+except: # If Japanese Support not installed
+    reading = importlib.import_module('MIAJapaneseSupport.reading')
 
+mecab = reading.MecabController()
+mecab.setup()
 
 #ANKI SPECIFIC
 def generateDefinitions(selectedNotes):
@@ -33,7 +40,6 @@ def generateDefinitions(selectedNotes):
                     if field in note:
                         if not note[field]:
                             note[field] = rtkKeywords
-
 
         src = None
         for field in conf.defSrcField:


### PR DESCRIPTION
Fixes #1. When running this addon on Anki 2.1, importing Mecab from the Japanese support plugin would not work for a couple of reasons. I made it to where Mecab can be imported as long as the Japanese Support addon or MIA Japanese Support addon is installed. Additionally, a tab inside config.py was causing an error, so I fixed that as well.